### PR TITLE
fix: directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,22 @@ on:
     branches:
       - master
   pull_request:
+env:
+  MINIO_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY_ID }}
+  MINIO_ACCESS_KEY_SECRET: ${{ secrets.MINIO_ACCESS_KEY_SECRET }}
+  MINIO_BUCKET: ${{ secrets.MINIO_BUCKET }}
 jobs:
-  test:
-    uses: goravel/.github/.github/workflows/test.yml@master
-    secrets: inherit
+  ubuntu:
+    strategy:
+      matrix:
+        go: [ "1.22" ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Install dependencies
+        run: go mod tidy
+      - name: Run tests
+        run: go test -timeout 1h ./...

--- a/minio_test.go
+++ b/minio_test.go
@@ -279,7 +279,7 @@ func TestStorage(t *testing.T) {
 			name: "Put",
 			setup: func() {
 				assert.Nil(t, driver.Put("Put/1.txt", "Goravel"))
-				assert.True(t, driver.Exists("Put"))
+				assert.True(t, driver.Exists("Put/"))
 				assert.True(t, driver.Exists("Put/1.txt"))
 				assert.True(t, driver.Missing("Put/2.txt"))
 				assert.Nil(t, driver.DeleteDirectory("Put"))
@@ -301,7 +301,7 @@ func TestStorage(t *testing.T) {
 				fileInfo := &File{path: "test.txt"}
 				path, err := driver.PutFile("PutFile", fileInfo)
 				assert.Nil(t, err)
-				assert.True(t, driver.Exists("PutFile"))
+				assert.True(t, driver.Exists("PutFile/"))
 				assert.True(t, driver.Exists(path))
 				data, err := driver.Get(path)
 				assert.Nil(t, err)


### PR DESCRIPTION
## 📑 Description

After a minio upgrade, Exist("a/") is not supported anymore, we need to fix it.

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced directory handling during file uploads
  - Improved robustness of MinIO client file operations

- **Bug Fixes**
  - Prevented inclusion of empty directory names
  - Ensured proper directory creation before file uploads

- **Tests**
  - Updated test assertions to verify directory existence with trailing slashes

- **Chores**
  - Updated GitHub Actions workflow to use Go 1.22
  - Added environment variables for MinIO configuration in CI/CD pipeline
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
