### PR TITLE
chore: update color package usage to support package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ toolchain go1.25.1
 
 require (
 	github.com/gabriel-vasile/mimetype v1.4.10
-	github.com/gookit/color v1.5.4
 	github.com/goravel/framework v1.16.3
 	github.com/minio/minio-go/v7 v7.0.95
 	github.com/stretchr/testify v1.11.0
@@ -27,6 +26,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gookit/color v1.5.4 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jmoiron/sqlx v1.4.0 // indirect

--- a/minio.go
+++ b/minio.go
@@ -10,15 +10,14 @@ import (
 	"time"
 
 	"github.com/gabriel-vasile/mimetype"
-	"github.com/gookit/color"
-	"github.com/goravel/framework/http"
-	"github.com/goravel/framework/support/carbon"
-	"github.com/minio/minio-go/v7"
-	"github.com/minio/minio-go/v7/pkg/credentials"
-
 	"github.com/goravel/framework/contracts/config"
 	"github.com/goravel/framework/contracts/filesystem"
+	"github.com/goravel/framework/http"
+	"github.com/goravel/framework/support/carbon"
+	"github.com/goravel/framework/support/color"
 	"github.com/goravel/framework/support/str"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
 /*
@@ -362,7 +361,7 @@ func (r *Minio) WithContext(ctx context.Context) filesystem.Driver {
 
 	driver, err := NewMinio(ctx, r.config, r.disk)
 	if err != nil {
-		color.Redf("init %s disk fail: %v\n", r.disk, err)
+		color.Red().Printfln("init %s disk fail: %v\n", r.disk, err)
 
 		return nil
 	}


### PR DESCRIPTION
## 📑 Description

Replaces direct usage of the external gookit/color package with the internal github.com/goravel/framework/support/color package, and updates the method calls for printing colored output. Additionally, the dependency on gookit/color is now marked as indirect in go.mod.

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
